### PR TITLE
[add]tag-index-create

### DIFF
--- a/app/assets/javascripts/admins/tags.coffee
+++ b/app/assets/javascripts/admins/tags.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admins/tags.scss
+++ b/app/assets/stylesheets/admins/tags.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admins::tags controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admins/tags_controller.rb
+++ b/app/controllers/admins/tags_controller.rb
@@ -1,0 +1,38 @@
+class Admins::TagsController < ApplicationController
+    
+    def index
+        @tag = Tag.new
+        @tags = Tag.all
+        @genres = Genre.all
+    end
+    
+    def create
+        @tag = Tag.new(tag_params)
+        @genres = Genre.all
+        @genres.each do |genre|
+            @tag.genre_id = genre.id
+        end
+        if @tag.save
+            flash[:notice] = 'タグの投稿に成功しました'
+            redirect_to admins_tags_path
+        else
+            flash[:notice] = 'error'
+            redirect_to admins_tags_path
+        end
+    end
+    
+    def edit
+    
+    end
+    
+    def update
+    end
+    
+    def destroy
+    end
+    
+    private
+    def tag_params
+        params.require(:tag).permit(:name, :introduction, :genre_id)
+    end
+end

--- a/app/helpers/admins/tags_helper.rb
+++ b/app/helpers/admins/tags_helper.rb
@@ -1,0 +1,2 @@
+module Admins::TagsHelper
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,3 @@
 class Genre < ApplicationRecord
-    
+    has_many :tags, dependent: :destroy
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+    belongs_to :genre
+end

--- a/app/views/admins/genres/index.html.erb
+++ b/app/views/admins/genres/index.html.erb
@@ -36,7 +36,7 @@
 </div>
 <div class="container form">
   <div class="row box">
-    <%= form_with model:@genre,url:admins_genres_path, class:"form-horizontal", locak:true do |f| %>
+    <%= form_with model:@genre,url:admins_genres_path, class:"form-horizontal", local:true do |f| %>
     <div class="form-group">
       <label class="col-sm-5 control-label">ジャンル名</label>
       <div class="col-sm-5">

--- a/app/views/admins/tags/index.html.erb
+++ b/app/views/admins/tags/index.html.erb
@@ -1,0 +1,70 @@
+<h2>タグ関連</h2>
+<div class="container">
+    <div class="row">
+        <ul>
+            <li>タグを追加できます</li>
+            <li>ユーザーは親ジャンルを指定する必要があるので、ジャンル名のタグという読み方が成立するのがベストです</li>
+        </ul>
+    </div>
+    <div class="row">
+        <table class="table table-bordered">
+        	<thead>
+        		<tr>
+        			<th>タグID</th>
+        			<th>タグ名</th>
+        			<th>タグ容説明</th>
+        			<th>親ジャンル</th>
+        			<th>編集・削除</th>
+        		</tr>
+        	</thead>
+        	<tbody>
+        	    <% @tags.each do |tag| %>
+        		<tr>
+        			<th><%= tag.id %></th>
+        			<td><%= tag.name %></td>
+        			<td><%= tag.introduction %></td>
+        			<td><%= tag.genre.name %></td>
+        			<td>
+        			    <%# link_to "編集", edit_admins_tag_path(genre.id), class:"btn btn-primary" %>
+        			    <%# link_to "削除", admins_tag_path(genre.id), method: :delete, class:"btn btn-danger" %>
+        			</td>
+        		</tr>
+        		<% end %>
+        	</tbody>
+        </table>
+    </div>
+</div>
+<div class="container form">
+  <div class="row box">
+    <%= form_with model:@tag, url:admins_tags_path, class:"form-horizontal", local:true do |f| %>
+    <div class="form-group">
+      <label class="col-sm-5 control-label">タグ名</label>
+      <div class="col-sm-5">
+        <%= f.text_field :name %>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-5 control-label">タグ内容</label>
+      <div class="col-sm-5">
+        <%= f.text_area :introduction, class:"form-control" %><br>
+      </div>
+    </div>
+    <div class="form-group"  id="exampleFormControlSelect1">
+      <label class="col-sm-5 control-label">親ジャンル選択</label>
+        <div class="col-sm-5">
+                  
+            <select class="form-control" id="exampleFormControlSelect1">
+               <% @genres.each do |genre| %>  
+               <option>
+                  <%= genre.name %> 
+               </option>
+               <% end %>
+            </select>
+          <br>
+        <%= f.submit "投稿する" %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ devise_for :users, controllers: {
     
     namespace :admins do
       resources :genres, only: [:index, :show, :create, :edit, :update, :destroy]
+      resources :tags, only: [:index, :show, :create, :edit, :update, :destroy]
     end
 
     get '/admins' => 'admins/homes#top'

--- a/db/migrate/20201220135045_create_tags.rb
+++ b/db/migrate/20201220135045_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tags do |t|
+      t.string :name,          null: false
+      t.string :introduction,   null: false
+      t.integer :genre_id      
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_20_094107) do
+ActiveRecord::Schema.define(version: 2020_12_20_135045) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -29,6 +29,14 @@ ActiveRecord::Schema.define(version: 2020_12_20_094107) do
     t.string "name", null: false
     t.text "introduction", null: false
     t.boolean "is_active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "introduction", null: false
+    t.integer "genre_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/admins/tags_controller_test.rb
+++ b/test/controllers/admins/tags_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admins::TagsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  introduction: MyString
+  genre_id: 1
+
+two:
+  name: MyString
+  introduction: MyString
+  genre_id: 1

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
[add]tagの投稿関連の設定

#tagに関する初期設定
- モデルの追加
- アソシセーションの設定
- コントローラーの追加
- viewファイルの追加
- ルーティングの追加

#投稿機能関連
- indexアクションの詳細追加
- createアクションの詳細追加

[bug]現在発生中のバグ
- タグを投稿するとジャンルのidが別のものになる
- 空投稿ができてしまう
