### PR TITLE
[add]tag-edit-destroy

### DIFF
--- a/app/controllers/admins/tags_controller.rb
+++ b/app/controllers/admins/tags_controller.rb
@@ -22,13 +22,28 @@ class Admins::TagsController < ApplicationController
     end
     
     def edit
-    
+        @tag = Tag.find(params[:id])
+        @genres = Genre.all
     end
     
     def update
+        @tag = Tag.find(params[:id])
+        if @tag.update(tag_params)
+            flash[:notice] = "編集に成功しました"
+            redirect_to admins_tags_path
+        else
+            flash[:notice] = "error"
+        end
     end
     
     def destroy
+        @tag = Tag.find(params[:id])
+        if @tag.destroy
+            flash[:notice] = "削除に成功しました"
+            redirect_to admins_tags_path
+        else
+            flash[:notice] = "error"
+        end
     end
     
     private

--- a/app/views/admins/tags/edit.html.erb
+++ b/app/views/admins/tags/edit.html.erb
@@ -1,0 +1,44 @@
+<h2>タグ関連(編集）</h2>
+<div class="container">
+    <div class="row">
+        <ul>
+            <li>タグを編集できます</li>
+            <li>タグは親ジャンルに紐づいています</li>
+            <li>編集はできますが、親ジャンルの変更や大きく記載内容が変わる場合はユーザーが混乱するので基本的にお勧めしません</li>
+        </ul>
+    </div>
+</div>
+<div class="container form">
+  <div class="row box">
+    <%= form_with model:@tag, url:admins_tag_path(@tag.id), method: :patch, class:"form-horizontal", local:true do |f| %>
+    <div class="form-group">
+      <label class="col-sm-5 control-label">タグ名</label>
+      <div class="col-sm-5">
+        <%= f.text_field :name %>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="col-sm-5 control-label">タグ内容</label>
+      <div class="col-sm-5">
+        <%= f.text_area :introduction, class:"form-control" %><br>
+      </div>
+    </div>
+    <div class="form-group"  id="exampleFormControlSelect1">
+      <label class="col-sm-5 control-label">親ジャンル選択</label>
+        <div class="col-sm-5">
+                  
+            <select class="form-control" id="exampleFormControlSelect1">
+               <% @genres.each do |genre| %>  
+               <option>
+                  <%= genre.id %>:<%= genre.name %>
+               </option>
+               <% end %>
+            </select>
+          <br>
+        <%= f.submit "更新する" %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admins/tags/index.html.erb
+++ b/app/views/admins/tags/index.html.erb
@@ -25,8 +25,8 @@
         			<td><%= tag.introduction %></td>
         			<td><%= tag.genre.name %></td>
         			<td>
-        			    <%# link_to "編集", edit_admins_tag_path(genre.id), class:"btn btn-primary" %>
-        			    <%# link_to "削除", admins_tag_path(genre.id), method: :delete, class:"btn btn-danger" %>
+        			    <%= link_to "編集", edit_admins_tag_path(tag.id), class:"btn btn-primary" %>
+        			    <%= link_to "削除", admins_tag_path(tag.id), method: :delete, class:"btn btn-danger" %>
         			</td>
         		</tr>
         		<% end %>
@@ -56,7 +56,7 @@
             <select class="form-control" id="exampleFormControlSelect1">
                <% @genres.each do |genre| %>  
                <option>
-                  <%= genre.name %> 
+                  <%= genre.id %>:<%= genre.name %> 
                </option>
                <% end %>
             </select>
@@ -68,3 +68,9 @@
     <% end %>
   </div>
 </div>
+<% @tags.each do |tag| %>
+  <%= tag.genre.name %>
+<% end %>
+<% @genres.each do |genre| %>
+  <%= genre.name %>
+<% end %>


### PR DESCRIPTION
[add]tagの投稿関連の設定

#編集機能関連

- editアクションの詳細追加
- updateアクションの詳細追加
- indexページにdestroyのボタン設置

#削除機能関連

- destroyアクションの詳細追加
- indexページにdestroyのボタン設置

[bug]現在発生中のバグ

- タグを投稿するとジャンルのidが別のものになる
- 空投稿ができてしまう
- flashメッセージが上手く表示されない（ヘッダーに隠れて上手く見えない）