### PR TITLE
[add]event-index-new

### DIFF
--- a/app/assets/javascripts/admins/events.coffee
+++ b/app/assets/javascripts/admins/events.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admins/events.scss
+++ b/app/assets/stylesheets/admins/events.scss
@@ -1,0 +1,14 @@
+// Place all the styles related to the admins::events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.box.event-new{
+    width :900px;
+    background-color:green;
+    // text-align: center;
+}
+
+.row.box.event-new {
+    text-align: left;
+}
+            

--- a/app/controllers/admins/events_controller.rb
+++ b/app/controllers/admins/events_controller.rb
@@ -1,0 +1,35 @@
+class Admins::EventsController < ApplicationController
+    
+    def index
+        @events = Event.all
+    end
+    
+    def new
+        @event = Event.new
+    end
+    
+    def create
+        @event = Event.new(event_params)
+        if @event.save
+            flash[:notice] = "イベントの追加に成功しました"
+            redirect_to admins_events_path
+        else
+            flash[:notice] = "error"
+            redirect_to admins_events_path
+        end
+    end
+    
+    def edit
+    end
+    
+    def update
+    end
+    
+    def destroy
+    end
+    
+    private
+    def event_params
+        params.require(:event).permit(:name, :date, :start, :finish, :entry_fee, :organizer, :event_detail, :evemt_status, :capacity, :cancel, :customer_id)
+    end
+end

--- a/app/helpers/admins/events_helper.rb
+++ b/app/helpers/admins/events_helper.rb
@@ -1,0 +1,2 @@
+module Admins::EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/views/admins/events/index.html.erb
+++ b/app/views/admins/events/index.html.erb
@@ -1,0 +1,38 @@
+<div class="container">
+    <div class="row">
+        <h3>イベント一覧ページ</h3>
+        <ul>
+            <li>イベントをできます</li>
+            <li>開催中のイベント名はトップページに表示されます</li>
+            <li>イベントは多すぎると管理ができません。</li>
+        </ul>
+    </div>
+    <div class="row">
+        <table class="table table-bordered">
+        	<thead>
+        		<tr>
+        			<th>No.</th>
+        			<th>イベント名</th>
+        			<th>イベント詳細</th>
+        			<th>編集・削除</th>
+        		</tr>
+        	</thead>
+        	<tbody>
+        	    <% @events.each do |event| %>
+        		<tr>
+        			<th><%= event.id %></th>
+        			<td><%= event.name %></td>
+        			<td><%= event.event_detail %></td>
+        			<td>
+        			    <%# link_to "編集", edit_admins_genre_path(genre.id), class:"btn btn-primary" %>
+        			    <%# link_to "削除", admins_genre_path(genre.id), method: :delete, class:"btn btn-danger" %>
+        			</td>
+        		</tr>
+        		<% end %>
+        	</tbody>
+        </table>
+    </div>
+    <div class="row" style="text-align:center;">
+        <%= link_to "イベント登録", new_admins_event_path, class:"btn btn-primary" %>
+    </div>
+</div>

--- a/app/views/admins/events/new.html.erb
+++ b/app/views/admins/events/new.html.erb
@@ -1,0 +1,81 @@
+    <h2>イベント追加</h2> 
+        <div class="container form">
+          <div class="box event-new">
+            <%= form_with model:@event, url:admins_events_path, class:"form-horizontal", local:true do |f| %>
+            <div class="form-group">
+              <label class="col-sm-5 control-label">イベント名</label>
+              <div class="col-sm-5">
+                <%= f.text_field :name %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">開催日</label>
+              <div class="col-sm-5">
+                <%= f.text_field :date %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">イベント開催時間</label>
+              <div class="col-sm-3">
+                <%= f.text_field :start %>
+              </div>
+              <div class="col-sm-1">
+                <p>〜</p>
+              </div>
+              <div class="col-sm-3">
+                <%= f.text_field :finish %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">参加費</label>
+              <div class="col-sm-5">
+                <%= f.text_field :entry_fee %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">募集人数</label>
+              <div class="col-sm-5">
+                <%= f.text_field :capacity %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">主催者</label>
+              <div class="col-sm-5">
+                <%= f.text_field :organizer %>
+              </div>
+            </div>
+            
+            <div class="form-group">
+              <label class="col-sm-5 control-label">イベント詳細</label>
+              <div class="col-sm-5">
+                <%= f.text_area :event_detail, class:"form-control" %><br>
+              </div>
+            </div>
+            <div class="form-group"  id="exampleFormControlSelect1">
+              <label class="col-sm-5 control-label">開催ステータス</label>
+                <div class="col-sm-5">
+                          
+                    <select class="form-control" id="exampleFormControlSelect1">
+                       <%# @.each do |genre| %>  
+                       <option>
+                           開催中
+                          <%# genre.name %> 
+                       </option>
+                       <option>
+                          準備中  
+                       </option>
+                       <%# end %>
+                    </select>
+                  <br>
+                <%= f.submit "投稿する" %>
+                </div>
+              </div>
+            </div>
+            <% end %>
+         </div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ devise_for :users, controllers: {
     }
     
     namespace :admins do
-      resources :genres, only: [:index, :show, :create, :edit, :update, :destroy]
-      resources :tags, only: [:index, :show, :create, :edit, :update, :destroy]
+      resources :genres, only: [:index, :create, :edit, :update, :destroy]
+      resources :tags, only: [:index, :create, :edit, :update, :destroy]
+      resources :events, only: [:index, :new, :create, :edit, :update, :destroy]
     end
 
     get '/admins' => 'admins/homes#top'

--- a/db/migrate/20201221033732_create_events.rb
+++ b/db/migrate/20201221033732_create_events.rb
@@ -1,0 +1,19 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.integer :customer_id
+      t.integer :date
+      t.integer :start
+      t.integer :finish
+      t.integer :entry_fee
+      t.string :organizer
+      t.text :event_detail
+      t.integer :event_status
+      t.integer :capacity
+      t.boolean :cancel
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_20_135045) do
+ActiveRecord::Schema.define(version: 2020_12_21_033732) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -23,6 +23,22 @@ ActiveRecord::Schema.define(version: 2020_12_20_135045) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.integer "customer_id"
+    t.integer "date"
+    t.integer "start"
+    t.integer "finish"
+    t.integer "entry_fee"
+    t.string "organizer"
+    t.text "event_detail"
+    t.integer "event_status"
+    t.integer "capacity"
+    t.boolean "cancel"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/test/controllers/admins/events_controller_test.rb
+++ b/test/controllers/admins/events_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admins::EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,27 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  customer_id: 1
+  date: 1
+  start: 1
+  finish: 1
+  entry_fee: 1
+  organizer: MyString
+  event_detail: MyText
+  event_status: 1
+  capacity: 1
+  cancel: false
+  name: MyString
+
+two:
+  customer_id: 1
+  date: 1
+  start: 1
+  finish: 1
+  entry_fee: 1
+  organizer: MyString
+  event_detail: MyText
+  event_status: 1
+  capacity: 1
+  cancel: false
+  name: MyString

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
[add]eventの一覧ページと投稿関連の設定

#eventの初期設定

- モデルの設定（カラムのnull :falseとかはまだ未実装）
- コントローラーの追加
- ルーティングの追加
- 空のアクションとviewを追加

#一覧ページ関連

- indexアクションの詳細追加
-indexのviewページ作成（表とリンク）

[bug]

- タグを投稿するとジャンルのidが別のものになる
- 空投稿ができてしまう
- flashメッセージが上手く表示されない（ヘッダーに隠れて上手く見えない）