### PR TITLE
[add]admin-user-index,show,confirm,destroy

### DIFF
--- a/app/assets/javascripts/admins/users.coffee
+++ b/app/assets/javascripts/admins/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admins/users.scss
+++ b/app/assets/stylesheets/admins/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admins::users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,3 +41,9 @@
     color: white;
     text-align: center;
 }
+
+.flash-ban {
+    background-color: gold;
+    color: black;
+    text-align: center;
+}

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -1,0 +1,29 @@
+class Admins::UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
+  def show
+    @users = User.all
+    @user = User.find(params[:id])
+  end
+  
+  def destroy
+    @user = User.find(params[:id])
+    if @user.destroy
+      flash[:notice] = 'BANしました！'
+    else
+      flash[:notice] = 'error'
+    end
+    redirect_to admins_users_path
+  end
+  
+  def confirm
+    @user = User.find(params[:id])
+  end
+  
+  private
+  def user_params
+    params.require(:user).permit(:name, :watchword, :encrypted_password, :popular, :is_deleted)
+  end
+end

--- a/app/helpers/admins/users_helper.rb
+++ b/app/helpers/admins/users_helper.rb
@@ -1,0 +1,2 @@
+module Admins::UsersHelper
+end

--- a/app/views/admins/events/index.html.erb
+++ b/app/views/admins/events/index.html.erb
@@ -32,7 +32,7 @@
         	</tbody>
         </table>
     </div>
-    <div class="row" style="text-align:center;">
+    <div class="row" style="text-align: center;">
         <%= link_to "イベント登録", new_admins_event_path, class:"btn btn-primary" %>
     </div>
 </div>

--- a/app/views/admins/users/confirm.html.erb
+++ b/app/views/admins/users/confirm.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+    <div class="cow">
+        <h3>注意！一度削除したユーザーは復活できません！</h3>
+        <p>本当にBANしますか！？</p>
+        <p>
+            <%= link_to "BANする", admins_user_path(@user.id), method: :delete, class:"btn btn-denger" %>
+            <%= link_to "やっぱやーめた", admins_user_path, class:"btn btn-primary" %>
+        </p>
+    </div>
+</div>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -1,0 +1,31 @@
+<div class="container">
+    <h3>ユーザー一覧</h3>
+    <div class="row">
+        <table class="table table-bordered">
+        	<thead>
+        		<tr>
+        			<th>会員ID</th>
+        			<th>ユーザー名</th>
+        			<th>投稿数</th>
+        			<th>質問数</th>
+        			<th>ステータス</th>
+        			<th>編集削除</th>
+        		</tr>
+        	</thead>
+        	<tbody>
+        	    <% @users.each do |user| %>
+        		<tr>
+        			<th><%= user.id %></th>
+        			<td><%= user.name %></td>
+        			<td>投稿数未実装</td>
+        			<td>質問数未実装</td>
+        			<td><%= user.is_deleted %></td>
+        			<td>
+        			    <%= link_to '詳細', admins_user_path(user.id), method: :get %> 
+        			</td>
+        		</tr>
+        		<% end %>
+        	</tbody>
+        </table>
+    </div>
+</div>

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -1,0 +1,54 @@
+<div class="container">
+    <h3><%= @user.name %>さんの記録詳細</h3>
+    <div class="row">
+        <p><%= @user.name %>のステータス:インフルエンサー　獲得いいね数:32個　ファンの数：23人</p>
+        <p>
+            <%= link_to "BANする", admins_confirm_path(@user.id), class:"btn btn-danger" %>
+        </p>
+    </div>
+    <div class="row">
+        <h3>投稿内容一覧</h3>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>投稿日時</th>
+                    <th>内容</th>
+                    <th>削除</th>
+                </tr>
+            </thead>
+        	<tbody>
+        		<tr>
+        			<th><%= @user.created_at %></th>
+        			<td><%= @user.name %></td>
+        			<td>投稿数未実装</td>
+        			<td>質問数未実装</td>
+        			<td><%= @user.is_deleted %></td>
+        		</tr>
+        	</tbody>
+        </table>
+    </div>
+    <div class="row">
+        <h>質問内容一覧</h>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>投稿日時</th>
+                    <th>内容</th>
+                    <th>削除</th>
+                </tr>
+            </thead>
+        	<tbody>
+        		<tr>
+        			<th><%= @user.id %></th>
+        			<td><%= @user.name %></td>
+        			<td>投稿数未実装</td>
+        			<td>質問数未実装</td>
+        			<td><%= @user.is_deleted %></td>
+        		</tr>
+        	</tbody>
+        </table>
+    </div>
+    <div class="row" style=text-align="center">
+        <%= link_to "質問一覧に戻る", admins_users_path, class:"btn btn-primary" %>
+    </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,6 +70,10 @@
         <div class="flash-error">
            <%= flash[:notice] %>
         </div>
+      <% elsif flash[:notice] == 'BANしました！'%>
+        <div class="flash-error">
+           <%= flash[:notice] %>
+        </div>
       <% else %>
         <P></P>
       <% end %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -5,9 +5,15 @@
         <h3>-誰でも投稿できるスキー百科事典-</h3>
     </div>
     <div class="row user-top-btn">
-        <div class="col-xs-4"><button class="btn btn-primary">質問をみる</button></div>
-        <div class="col-xs-4"><button class="btn btn-danger">会員登録</button></div>
-        <div class="col-xs-4"><button class="btn btn-primary">投稿を見る</button></div>
+        <div class="col-xs-4">
+            <%= link_to "質問を見る", root_path, class:"btn btn-primary" %>
+        </div>
+        <div class="col-xs-4">
+            <%= link_to "会員登録", new_user_registration_path, class:"btn btn-danger" %>
+        </div>
+        <div class="col-xs-4">
+            <%= link_to "投稿を見る", root_path, class:"btn btn-primary" %>
+        </div>
     </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   
+  namespace :admins do
+    get 'users/index'
+    get 'users/show'
+  end
   devise_for :admins, controllers: {
       sessions:      'admins/sessions',
       passwords:     'admins/passwords',
@@ -19,7 +23,12 @@ devise_for :users, controllers: {
       resources :genres, only: [:index, :create, :edit, :update, :destroy]
       resources :tags, only: [:index, :create, :edit, :update, :destroy]
       resources :events, only: [:index, :new, :show, :create, :edit, :update, :destroy]
+      resources :users, only: [:index, :edit, :update, :destroy, :show]
+      # get 'users/confirm/:id' => 'admins/users#confirm'
     end
+    
+    # post '/orders/confirm' => 'orders#confirm'
+    get 'admins/users/confirm/:id' => 'admins/users#confirm',  as: 'admins_confirm'
 
     get '/admins' => 'admins/homes#top'
     root 'public/homes#top'

--- a/test/controllers/admins/users_controller_test.rb
+++ b/test/controllers/admins/users_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Admins::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admins_users_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admins_users_show_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
[add]admin/usersのindex,show,destroy,confirm関連の追加
- users_controllerの編集


一覧ページの追加
- indexアクションのの詳細追加
-indexのviewページ作成（表とリンク）

詳細ページの追加
- showアクションのの詳細追加
-showのviewページ作成（表とリンク）

確認ページの追加
- confirmアクションのの詳細追加
-confirmのviewページ作成

削除機能実装
- destroyアクションの追加
- 削除完了後、一覧画面にリダイレクトの後フラッシュメッセージが表示されるように設定
(applictation.htmlとapplication.scssに追記）